### PR TITLE
initial draft of changes to adapt to new api

### DIFF
--- a/src/lib/components/SensorTypeWithTooltip.svelte
+++ b/src/lib/components/SensorTypeWithTooltip.svelte
@@ -6,24 +6,24 @@
 	import HighlightedSearchQuery from './HighlightedSearchQuery.svelte';
 
 	interface Props {
-		type: 'biomet' | 'temprh';
+		type: 'biomet' | 'temprh' | 'double';
 		searchQuery?: string;
 	}
 
 	let { type, searchQuery }: Props = $props();
 
 	let title = $derived(
-		type === 'biomet'
+		type === 'biomet' || type === 'double'
 			? $LL.pages.stations.table.cells.stationTypes.biomet.title()
 			: $LL.pages.stations.table.cells.stationTypes.temprh.title()
 	);
 	let description = $derived(
-		type === 'biomet'
+		type === 'biomet' || type === 'double'
 			? $LL.pages.stations.table.cells.stationTypes.biomet.description()
 			: $LL.pages.stations.table.cells.stationTypes.temprh.description()
 	);
 	let triggerLabel = $derived(
-		type === 'biomet'
+		type === 'biomet' || type === 'double'
 			? $LL.pages.stations.table.cells.stationTypes.biomet.nameShort()
 			: $LL.pages.stations.table.cells.stationTypes.temprh.nameShort()
 	);
@@ -31,7 +31,7 @@
 	let units = $derived(
 		Object.entries($LL.pages.measurements.unitSelect.units)
 			.filter(([key]) =>
-				type === 'biomet'
+				type === 'biomet' || type === 'double'
 					? true
 					: ['utci', 'air_temperature', 'pet', 'absolute_humidity'].includes(key)
 			)

--- a/src/lib/stores/mapData.ts
+++ b/src/lib/stores/mapData.ts
@@ -19,7 +19,10 @@ export function filterDoubleStations(stations: StationMetadata[]) {
 	for (const station of stations) {
 		const key = [station.longName, station.longitude, station.latitude].join('-');
 		const existringStation = stationsByName.get(key);
-		if (existringStation && existringStation.stationType === 'biomet') {
+		if (
+			existringStation &&
+			(existringStation.stationType === 'biomet' || station.stationType === 'double')
+		) {
 			continue;
 		}
 		stationsByName.set(key, station);
@@ -30,7 +33,7 @@ export function filterDoubleStations(stations: StationMetadata[]) {
 
 export async function fetchStations() {
 	const stationsMetadata = await api().getStationsMetadata();
-	const filteredStations = filterDoubleStations(stationsMetadata)
+	const filteredStations = filterDoubleStations(stationsMetadata);
 	const stationsGeoJSONFeatures = filteredStations.map((station) => ({
 		id: station.id,
 		type: 'Feature' as const,

--- a/src/lib/stores/stationsStore.ts
+++ b/src/lib/stores/stationsStore.ts
@@ -3,7 +3,7 @@ import { writable } from "svelte/store";
 import { queryParam, ssp } from "sveltekit-search-params";
 import type { StationsGeoJSONType } from "./mapData";
 
-const defaultStations = ["DEC005304", "DEC005476", "DEC00546E"];
+const defaultStations = ["DOBHBF", "DODFRP", "DODGWS"];
 const urlStations = writable(defaultStations);
 const queryParamStations = queryParam(
 	"selectedStations",

--- a/src/lib/utils/parsingUtil.ts
+++ b/src/lib/utils/parsingUtil.ts
@@ -2,23 +2,23 @@ import { z } from 'zod';
 import type { RawStationMetadata } from './schemas';
 
 export function parseStationMetadata({
-	name,
+	station_id,
 	long_name,
 	station_type,
 	...rest
 }: RawStationMetadata) {
 	return {
 		...rest,
-		id: name,
+		id: station_id,
 		longName: long_name,
 		stationType: station_type
 	};
 }
 
-export function parseRawStationNameToId({ name, ...rest }: { name?: string }) {
+export function parseRawStationNameToId({ station_id, ...rest }: { station_id?: string }) {
 	return {
 		...rest,
-		id: name
+		id: station_id
 	};
 }
 

--- a/src/lib/utils/schemas.ts
+++ b/src/lib/utils/schemas.ts
@@ -2,10 +2,10 @@ import { z } from 'zod';
 import { parseRawStationNameToId, parseStationMetadata } from './parsingUtil';
 
 // STATIONS
-export const StationTypeSchema = z.enum(['biomet', 'temprh']);
+export const StationTypeSchema = z.enum(['biomet', 'temprh', 'double']);
 
 export const RawStationMetadataSchema = z.object({
-	name: z.string(),
+	station_id: z.string(),
 	long_name: z.string(),
 	latitude: z.number(),
 	longitude: z.number(),
@@ -23,7 +23,7 @@ export type StationMetadata = z.infer<typeof ParsedStationMetadataSchema>;
 // UNITS
 const meadurementDateSchema = z.object({
 	measured_at: z.string().optional(),
-	name: z.string().optional(),
+	station_id: z.string().optional(),
 	station_type: StationTypeSchema.optional()
 });
 const mD = meadurementDateSchema;


### PR DESCRIPTION
Hey @vogelino,
I played around locally a bit and had a quick look at what had to change to get the dashboard working again.
This is just an idea what I found at a first glance. Feel free to use this as a starting point, but no need to merge this since I know nothing about type script and svelte.

The change to [`/metadata`](https://api.data2resilience.de/docs#/stations/get_stations_metadata_v1_stations_metadata_get) came out a bit different. So to keep the behavior you previously had, you will have to pass the param names, otherwise it will send you all we got.

I will let you know the other details via email so the others are also up to date.