### PR TITLE
also fully zero pad the tile map url

### DIFF
--- a/src/lib/components/Map/MapMeasurementsRasterLayer.svelte
+++ b/src/lib/components/Map/MapMeasurementsRasterLayer.svelte
@@ -53,9 +53,10 @@
 	const tilesUrls = $derived(
 		hours.map((h) => {
 			const paddedHour = `${h}`.padStart(2, '0');
+			const paddeddayOfYearToday = String(dayOfYearToday).padStart(3, '0');
 			return {
 				layerHour: h,
-				tilesUrl: `${PUBLIC_API_BASE_URL}/tms/singleband/${unit}/${year}/${dayOfYearToday}/${paddedHour}/{z}/{x}/{y}.png?colormap=turbo&tile_size=[256,256]`
+				tilesUrl: `${PUBLIC_API_BASE_URL}/tms/singleband/${unit}/${year}/${paddeddayOfYearToday}/${paddedHour}/{z}/{x}/{y}.png?colormap=turbo&tile_size=[256,256]`
 			};
 		})
 	);


### PR DESCRIPTION
Since we now have up-to-date rasters, I noticed, that the requests still 404. So 9b6126c fixed the call to `/metadata`, but did not fix `/singleband`. This fixes it.

What I was not able to address is, that the hour is in UTC, but the time in the UI should be the users's time (or maybe better local time in Dortmund? At least consistent with the plots) so we need to convert the hour to UTC for the calls to work.

Another thing would be to have the 24 hours as a moving window i.e. `now - 24h` which may include two day-of-years. So this array of urls likely has to change a bit more.