### PR TITLE
make raster cmaps match measurement cmaps

### DIFF
--- a/src/lib/components/ChoroplethLegend.svelte
+++ b/src/lib/components/ChoroplethLegend.svelte
@@ -132,9 +132,11 @@
 					date: finalLocalDate,
 					unit: $heatStressUnit
 				});
+				const cmap = $heatStressUnit === 'relative_humidity' ? 'ylgnbu' : 'turbo';
 				let colormap = await api().getHeatStressColormap({
 					rangeStart: metadata?.range[0] || 0,
-					rangeEnd: metadata?.range[1] || 100
+					rangeEnd: metadata?.range[1] || 100,
+					cmap: cmap,
 				});
 				if (!colormap)
 					return {

--- a/src/lib/components/ChoroplethLegend.svelte
+++ b/src/lib/components/ChoroplethLegend.svelte
@@ -132,7 +132,12 @@
 					date: finalLocalDate,
 					unit: $heatStressUnit
 				});
-				const cmap = $heatStressUnit === 'relative_humidity' ? 'ylgnbu' : 'turbo';
+				let cmap = 'turbo';
+				if ($heatStressUnit === 'relative_humidity') {
+					cmap = 'ylgnbu';
+				} else if ($heatStressUnit === 'air_temperature') {
+					cmap = 'spectral_r';
+				}
 				let colormap = await api().getHeatStressColormap({
 					rangeStart: metadata?.range[0] || 0,
 					rangeEnd: metadata?.range[1] || 100,

--- a/src/lib/components/Map/MapMeasurementsRasterLayer.svelte
+++ b/src/lib/components/Map/MapMeasurementsRasterLayer.svelte
@@ -112,8 +112,16 @@
 			const { doy, param, year } = finalConfig;
 			const paddedHour = `${h}`.padStart(2, '0');
 			const paddedDayOfYear = `${doy}`.padStart(3, '0');
+			let colormap = 'turbo';
+			if (param.endsWith('_CLASS')) {
+				colormap = 'explicit';
+			} else if (param === 'RH') {
+				colormap = 'ylgnbu';
+			} else {
+				colormap = 'turbo';
+			}
 			const queryParameters: Record<string, string> = {
-				colormap: param.endsWith('_CLASS') ? 'explicit' : 'turbo',
+				colormap: colormap,
 				tile_size: '[256, 256]'
 			};
 			if (param.endsWith('_CLASS')) {

--- a/src/lib/components/Map/MapMeasurementsRasterLayer.svelte
+++ b/src/lib/components/Map/MapMeasurementsRasterLayer.svelte
@@ -117,6 +117,8 @@
 				colormap = 'explicit';
 			} else if (param === 'RH') {
 				colormap = 'ylgnbu';
+			} else if (param === 'TA') {
+				colormap = 'spectral_r';
 			} else {
 				colormap = 'turbo';
 			}

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -133,9 +133,9 @@ export const api = (customFetch = fetch) => ({
 		const data = await parseData(response, HeatStressMetadataSchema);
 		return data;
 	},
-	getHeatStressColormap: async (params: { rangeStart: number; rangeEnd: number }) => {
+	getHeatStressColormap: async (params: { rangeStart: number; rangeEnd: number; cmap: string }) => {
 		const response = await customFetch(
-			`${PUBLIC_API_BASE_URL}/tms/colormap?stretch_range=%5B${params.rangeStart},${params.rangeEnd}%5D&colormap=turbo`
+			`${PUBLIC_API_BASE_URL}/tms/colormap?stretch_range=%5B${params.rangeStart},${params.rangeEnd}%5D&colormap=${params.cmap}`
 		);
 
 		if (!response.ok && response.status === 422) return null;


### PR DESCRIPTION
I did forget the colormaps of the rasters last time we changed the measurement colors. Now they did not match. I changed that.
This is not the most robust nor flexible way, but I'd say good enough?