### PR TITLE
make download of station data start instantly

### DIFF
--- a/src/lib/components/DataDownloadButtonWithTooltip.svelte
+++ b/src/lib/components/DataDownloadButtonWithTooltip.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { LL } from '$i18n/i18n-svelte';
-	import { api } from '$lib/utils/api';
-	import { Download, LoaderCircle } from 'lucide-svelte';
+	import { Download } from 'lucide-svelte';
 	import Button from './ui/button/button.svelte';
+	import { PUBLIC_API_BASE_URL } from '$env/static/public';
 	import {
 		PopoverTooltip,
 		PopoverTooltipContent,
@@ -14,35 +14,18 @@
 	};
 
 	let { id }: Props = $props();
-	let isLoading = $state(false);
-
-	async function handleDownload() {
-		isLoading = true;
-		try {
-			const data = await api().downloadStationData({ id });
-			if (!data) return;
-			const blob = new Blob([data], { type: 'text/csv' });
-			const url = URL.createObjectURL(blob);
-			const link = document.createElement('a');
-			link.href = url;
-			link.download = `${id}.csv`;
-			link.click();
-		} catch (error) {
-			console.error(error);
-		} finally {
-			isLoading = false;
-		}
-	}
 </script>
 
 <PopoverTooltip openDelay={10} disableHoverableContent>
 	<PopoverTooltipTrigger tabindex={-1}>
-		<Button variant="ghost" size="icon" class="p-0" onclick={handleDownload}>
-			{#if isLoading}
-				<LoaderCircle class="size-5 shrink-0 animate-spin text-muted-foreground" />
-			{:else}
-				<Download class="size-5 shrink-0 text-muted-foreground" />
-			{/if}
+		<Button
+			variant="ghost"
+			size="icon"
+			class="p-0"
+			href="{PUBLIC_API_BASE_URL}/v1/download/{id}"
+			download="{id}.csv"
+		>
+			<Download class="size-5 shrink-0 text-muted-foreground" />
 		</Button>
 	</PopoverTooltipTrigger>
 	<PopoverTooltipContent>


### PR DESCRIPTION
This is kinda what I had in mind.

https://github.com/user-attachments/assets/ab81d2c5-2e4a-45dd-9411-4fd166c7085b

The only downside could be that potential errors are not handled nicely and the user may see a json page in the rare case something goes wrong.

I'll just put that out here for reference and we can see how "bad" the pre-fetching becomes.

I would also still argue that the default of downloading all data should stay as is. It's simple and if you only need a bit of data, just delete the rest - it does not hurt.